### PR TITLE
fix: use valid relative path format in marketplace.json source field

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "neurodivergent-visual-org",
-      "source": ".",
+      "source": "./",
       "description": "Create ADHD-friendly visual organizational tools (Mermaid diagrams) optimized for neurodivergent thinking patterns with accessibility modes",
       "version": "3.1.1",
       "author": {


### PR DESCRIPTION
## Summary

- Fixes the `source` field in `.claude-plugin/marketplace.json` to use valid relative path format (`"./"` instead of `"."`)

## Problem

When trying to add this plugin marketplace via Claude Code CLI:
```
/plugin marketplace add JackReis/neurodivergent-visual-org
```

The following error is returned:
```
Error: Invalid schema: plugins.0.source: Invalid input
```

## Root Cause

The Claude Code plugin schema requires relative paths in the `source` field to start with `./`. The current value of `"."` is not recognized as a valid source format.

Valid source formats are:
- Relative paths starting with `./` (e.g., `"./"`, `"./plugins/foo"`)
- GitHub object: `{"source": "github", "repo": "owner/repo"}`
- Git URL object: `{"source": "url", "url": "https://..."}`

## Solution

Update the `source` field from `"."` to `"./"` in `.claude-plugin/marketplace.json` (line 15).

## Testing

- [x] Verified JSON syntax is valid
- [x] Verified plugin structure matches source reference (`.claude-plugin/plugin.json` exists)
- [x] Verified skills path `./skills/neurodivergent-visual-org/SKILL.md` exists and is accessible

## Before/After

**Before:**
```json
"source": ".",
```

**After:**
```json
"source": "./",
```

---

🤖 Generated with [Claude Code](https://claude.ai/code)